### PR TITLE
Add caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 npm-debug.log
+test/cache
+test/fixtures/*.actual.css

--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ Default: `_`
 
 The file extension sometimes prepended to partials being imported.
 
+#### `cacheDir`
+
+Type: `String`
+Default: `null`
+
+The directory to store cached includes in. Can reduce compilation time when there are a lot of `@include`s.
+
+Setting this property enables the cache.
+
 [ci]: https://travis-ci.org/jonathantneal/postcss-partial-import
 [ci-img]: https://travis-ci.org/jonathantneal/postcss-partial-import.svg
 [Gulp PostCSS]: https://github.com/postcss/gulp-postcss

--- a/package.json
+++ b/package.json
@@ -1,41 +1,43 @@
 {
-	"name": "postcss-partial-import",
-	"version": "1.1.1",
-	"description": "PostCSS plugin that imports like Sass",
-	"keywords": [
-		"postcss",
-		"css",
-		"postcss-plugins",
-		"sass",
-		"scss",
-		"imports",
-		"files"
-	],
-	"author": "Jonathan Neal <jonathantneal@hotmail.com>",
-	"license": "CC0-1.0",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/jonathantneal/postcss-partial-import.git"
-	},
-	"bugs": {
-		"url": "https://github.com/jonathantneal/postcss-partial-import/issues"
-	},
-	"homepage": "https://github.com/jonathantneal/postcss-partial-import",
-	"dependencies": {
+  "name": "postcss-partial-import",
+  "version": "1.1.1",
+  "description": "PostCSS plugin that imports like Sass",
+  "keywords": [
+    "postcss",
+    "css",
+    "postcss-plugins",
+    "sass",
+    "scss",
+    "imports",
+    "files"
+  ],
+  "author": "Jonathan Neal <jonathantneal@hotmail.com>",
+  "license": "CC0-1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jonathantneal/postcss-partial-import.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jonathantneal/postcss-partial-import/issues"
+  },
+  "homepage": "https://github.com/jonathantneal/postcss-partial-import",
+  "dependencies": {
     "fs-readfile-promise": "^2.0.1",
-		"postcss": "^5.0.4"
-	},
-	"devDependencies": {
-		"chai": "^3.2.0",
-		"gulp": "^3.9.0",
-		"gulp-eslint": "^1.0.0",
-		"gulp-mocha": "^2.1.3"
-	},
-	"scripts": {
-		"test": "gulp"
-	},
-	"engines": {
-		"iojs": ">=2.0.0",
-		"node": ">=0.12.0"
-	}
+    "mkdirp": "^0.5.1",
+    "postcss": "^5.0.4",
+    "string-hash": "^1.1.0"
+  },
+  "devDependencies": {
+    "chai": "^3.2.0",
+    "gulp": "^3.9.0",
+    "gulp-eslint": "^1.0.0",
+    "gulp-mocha": "^2.1.3"
+  },
+  "scripts": {
+    "test": "gulp"
+  },
+  "engines": {
+    "iojs": ">=2.0.0",
+    "node": ">=0.12.0"
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -78,5 +78,5 @@ describe('postcss-partial-import', function () {
 			expect(Object.keys(cache).length).to.eql(10);
 			testFixture('basic', { cacheDir: path.join(__dirname, 'cache') }, done);
 		});
-	})
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -71,4 +71,12 @@ describe('postcss-partial-import', function () {
 	it('handles media queried imports', function (done) {
 		testFixture('media', {}, done);
 	});
+
+	it('caches results', function (done) {
+		testFixture('basic', { cacheDir: path.join(__dirname, 'cache') }, function () {
+			var cache = require( path.join(__dirname, 'cache', 'imports.json'));
+			expect(Object.keys(cache).length).to.eql(10);
+			testFixture('basic', { cacheDir: path.join(__dirname, 'cache') }, done);
+		});
+	})
 });


### PR DESCRIPTION
Added a `cacheDir` option. When set, it will enable the cache functionality and store the compiled output(s) along with a dependency graph in the specified directory. Modifying any of the files in the dependency graph invalidates the cache for that file and any dependents. Any unmodified dependencies will continue to be cached. 

Illustration depicting how the cache invalidation mechanism works: 

<img src="https://camo.githubusercontent.com/54f84d03570daa47fbcd38a8faf47b4936b7e3cb/687474703a2f2f692e696d6775722e636f6d2f737052756373572e706e67" />
