### PR TITLE
Add dependency to

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ Default: `null`
 
 The directory to store cached includes in. Can reduce compilation time when there are a lot of `@include`s. Setting this property enables the cache.
 
+#### `addDependencyTo`
+
+Type: `function`
+Default: `null`
+
+To pass CSS @import files to a compiler (such as webpack), which would otherwise not know which CSS files to watch for browser reloading.
+
+Example:
+
+```javascript
+// webpack.config.js
+postcss: function(webpack) {
+    return [
+        precss({ addDependencyTo: webpack })
+    ];
+},
+```
+
 [ci]: https://travis-ci.org/jonathantneal/postcss-partial-import
 [ci-img]: https://travis-ci.org/jonathantneal/postcss-partial-import.svg
 [Gulp PostCSS]: https://github.com/postcss/gulp-postcss

--- a/README.md
+++ b/README.md
@@ -138,19 +138,19 @@ The option if partials should be generated if they do not already exist.
 
 #### `cachedir`
 
-Type: `String`
+Type: `String``  
 Default: `null`
 
 The directory to store cached includes in. Can reduce compilation time when there are a lot of `@include`s. Setting this property enables the cache.
 
 #### `addDependencyTo`
 
-Type: `function`
+Type: `function`  
 Default: `null`
 
 To pass CSS @import files to a compiler (such as webpack), which would otherwise not know which CSS files to watch for browser reloading.
 
-Example:
+*Example*
 
 ```javascript
 // webpack.config.js

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The option if partials should be generated if they do not already exist.
 
 #### `cachedir`
 
-Type: `String``  
+Type: `String`  
 Default: `null`
 
 The directory to store cached includes in. Can reduce compilation time when there are a lot of `@include`s. Setting this property enables the cache.

--- a/index.js
+++ b/index.js
@@ -140,10 +140,7 @@ module.exports = postcss.plugin('postcss-partial-import', function (opts) {
 
 				// Only add dependencies when first adding file to the cache.
 				// Code reused from postcss-import: https://github.com/postcss/postcss-import
-				if (
-					typeof opts.addDependencyTo === "object" &&
-					typeof opts.addDependencyTo.addDependency === "function"
-				) {
+				if (typeof opts.addDependencyTo === 'object' && typeof opts.addDependencyTo.addDependency === 'function') {
 					opts.addDependencyTo.addDependency(fromPath);
 				}
 

--- a/index.js
+++ b/index.js
@@ -138,6 +138,15 @@ module.exports = postcss.plugin('postcss-partial-import', function (opts) {
 					imports.push(importRule(atRule, result, fromPath, cache));
 				});
 
+				// Only add dependencies when first adding file to the cache.
+				// Code reused from postcss-import: https://github.com/postcss/postcss-import
+				if (
+					typeof opts.addDependencyTo === "object" &&
+					typeof opts.addDependencyTo.addDependency === "function"
+				) {
+					opts.addDependencyTo.addDependency(fromPath);
+				}
+
 				Promise.all(imports).then(function () {
 					if (fromPath && cache) {
 						cache[fromPath] = cache[fromPath] || {};


### PR DESCRIPTION
From Readme: "To pass CSS @import files to a compiler (such as webpack), which would otherwise not know which CSS files to watch for browser reloading."

This resolves the request at #9. It is has been discussed at length at this [Precss issue](https://github.com/jonathantneal/precss/issues/6).

This code is based on the solution in [postcss-import](https://github.com/postcss/postcss-import/blob/master/index.js#L60).

An [indepth overview of the problem](http://stackoverflow.com/questions/35357799/webpack-and-precss-not-reloading-on-import-file-change) I was trying to solve.
