### PR TITLE
Apply addDependency to nested imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,11 @@ module.exports = postcss.plugin('postcss-partial-import', function (opts) {
 
 					// Push the promise into the imports array
 					imports.push(importPromise);
+
+					// Add a dependency on the nested import
+					if (hasAddDependencyMethod) {
+						opts.addDependencyTo.addDependency(path.join(dir, link));
+					}
 				}
 			}
 		});


### PR DESCRIPTION
I'm using `addDependencyTo` to enable hot reloading with webpack. It works for all files imported by ES6 `import` statements, but isn't applied to the files imported using `@import` _within_ those imported css files. This change just runs `addDependency` (if set) on the nested imported files.
