### PR TITLE
Add resolve option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ postcss: function(webpack) {
 }
 ```
 
+#### `resolve`
+
+Type: `function`
+Default: `null`
+
+Overrides the default function for resolving paths. The function will fall back to the default resolving behaviour if nothing is returned. The function will receive four arguments:
+
+* `id`: The `@import` string to be resolved
+* `dir`: The directory of the source file
+* `options`: All options passed in to the plugin
+
 [ci]:      https://travis-ci.org/jonathantneal/postcss-partial-import
 [ci-img]:  https://img.shields.io/travis/jonathantneal/postcss-partial-import.svg
 [npm]:     https://www.npmjs.com/package/postcss-partial-import

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = postcss.plugin('postcss-partial-import', function (opts) {
 		generate:  false,
 		plugins:   [],
 		prefix:    '_',
-		addDependencyTo: false
+		addDependencyTo: false,
+		resolve: null
 	}, opts);
 
 	if (!Array.isArray(opts.dirs)) {
@@ -93,7 +94,7 @@ module.exports = postcss.plugin('postcss-partial-import', function (opts) {
 		// For each possible directory (starting with the current)
 		[dir].concat(opts.dirs).forEach(function (localdir) {
 			// File relative to the local directory
-			var localfile = getPath(path.resolve(localdir, link), opts.prefix, opts.extension);
+			var localfile = getPath(link, localdir, opts);
 
 			// Promise the local CSS file is processed
 			localPromise = localPromise.catch(function () {
@@ -110,7 +111,7 @@ module.exports = postcss.plugin('postcss-partial-import', function (opts) {
 		var generateLocalPromise = npmPromise.catch(function () {
 			if (opts.generate) {
 				// File relative to the local directory
-				var localfile = getPath(path.resolve(dir, link), opts.prefix, opts.extension);
+				var localfile = getPath(link, dir, opts);
 
 				return makeCSS(localfile, processor);
 			}

--- a/lib/getPath.js
+++ b/lib/getPath.js
@@ -1,7 +1,17 @@
 var path = require('path');
 
 // Resolved file path
-module.exports = function getPath(link, prefix, extension) {
+module.exports = function getPath(id, dir, opts) {
+
+	var link = path.resolve(dir, id);
+
+	if (opts.resolve && typeof opts.resolve === 'function') {
+		var resolved = opts.resolve(id, dir, opts);
+		if (resolved) {
+			link = resolved;
+		}
+	}
+
 	// the extension of the path
 	var extName = path.extname(link);
 
@@ -9,7 +19,7 @@ module.exports = function getPath(link, prefix, extension) {
 		return link;
 	} else {
 		// the normalized path which includes a prefix and suffix
-		var normalizedPath = path.join(path.dirname(link), prefix + path.basename(link) + extension);
+		var normalizedPath = path.join(path.dirname(link), opts.prefix + path.basename(link) + opts.extension);
 
 		return normalizedPath;
 	}

--- a/test.js
+++ b/test.js
@@ -34,6 +34,18 @@ var tests = {
 		'package': {
 			message: 'allows package imports'
 		},
+		'resolve': {
+			message: 'resolves file paths with option',
+			options: {
+				resolve: function (id) {
+					if (/level1/.test(id)) {
+						// Skip straight to level 4
+						var dir = path.join(testdir, 'level1', 'level2', 'level3', 'level4')
+						return id.replace('level1', path.resolve(dir));
+					}
+				}
+			}
+		},
 		'web': {
 			message: 'ignores remote imports'
 		}

--- a/test/resolve.css
+++ b/test/resolve.css
@@ -1,0 +1,5 @@
+.level-0 {
+    background-color: black;
+}
+
+@import "level1/foo";

--- a/test/resolve.expect.css
+++ b/test/resolve.expect.css
@@ -1,0 +1,27 @@
+.level-0 {
+    background-color: black;
+}
+
+.level-4 {
+    background-color: black;
+}
+
+.level-4-bar {
+    background-color: black;
+}
+
+.level-3-bar {
+    background-color: black;
+}
+
+.level-2-bar {
+    background-color: black;
+}
+
+.level-1-bar {
+    background-color: black;
+}
+
+.level-1-qux {
+    background-color: black;
+}


### PR DESCRIPTION
Tried to keep it as similar as possible to the [`postcss-import` equivalent](https://github.com/postcss/postcss-import#resolve). Basically just tweaked the `getPath` util to use `opts.resolve` (if it exists and returns something) to override the default `path.resolve` behaviour.
