### PR TITLE
fix for incorrect prefix handling when compiling on windows

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -52,6 +52,12 @@ module.exports = {
 			options: {
 				extension: '.pcss'
 			}
+		},
+		'06-prefix/test': {
+			message: 'supports { prefix: "_" } usage',
+			options: {
+				prefix: '_'
+			}
 		}
 	}
 };

--- a/lib/resolve-id.js
+++ b/lib/resolve-id.js
@@ -30,10 +30,13 @@ module.exports = (id, base, options) => resolveId(id, base, options).catch(
 	(error) => {
 		let altId = id;
 
+		// match forward slash or backslash
+		let sepsRegex = '[/|\\]';
+
 		// when the prefix option is truthy
 		if (options.prefix) {
 			// prefixed file path matcher
-			const prefixMatch = RegExp(`(${ escapeRegExp(path.sep) })?(${ escapeRegExp(options.prefix) })?([^${ escapeRegExp(path.sep) }]+)$`);
+			const prefixMatch = RegExp(`(${ escapeRegExp(sepsRegex) })?(${ escapeRegExp(options.prefix) })?([^${ escapeRegExp(sepsRegex) }]+)$`);
 
 			// prefixed file path
 			altId = altId.replace(prefixMatch, `$1${ options.prefix }$3`);

--- a/test/06-prefix/dir1/_import2.css
+++ b/test/06-prefix/dir1/_import2.css
@@ -1,0 +1,3 @@
+a {
+	color: blue;
+}

--- a/test/06-prefix/dir1/_import3.css
+++ b/test/06-prefix/dir1/_import3.css
@@ -1,0 +1,3 @@
+a {
+	color: green;
+}

--- a/test/06-prefix/test.css
+++ b/test/06-prefix/test.css
@@ -1,0 +1,2 @@
+@import "./dir1/import2";
+@import ".\\dir1\\import3";

--- a/test/06-prefix/test.expect.css
+++ b/test/06-prefix/test.expect.css
@@ -1,0 +1,6 @@
+a {
+	color: blue;
+}
+a {
+	color: green;
+}


### PR DESCRIPTION
When running on Windows ```path.sep``` is ```\``` however ```@import``` statements generally use ```/``` regardless of platform. This was causing the prefix to be incorrectly applied. The loader was looking for e.g. ```_src/styles/settings.css``` instead of ```src/styles/_settings.css```

I have added a test to verify that it now works for either kind of separator. I did have some issues with carriage-returns/line-feeds in some of the existing tests, so you may need to fix these up.

Hope it's all ok, let me know if you need anything else done, many thanks for your work.